### PR TITLE
add missing parameters mu and friction8

### DIFF
--- a/src/compas_rbe/equilibrium/interfaceforces/interfaceforces_cvx.py
+++ b/src/compas_rbe/equilibrium/interfaceforces/interfaceforces_cvx.py
@@ -138,7 +138,7 @@ def compute_interface_forces_cvx(assembly,
     # inequality constraints
     # ==========================================================================
 
-    G = make_Aiq(vcount, False)
+    G = make_Aiq(vcount, friction8, mu)
     G = G.toarray()
 
     # print(G.shape)


### PR DESCRIPTION
add missing parameters mu and friction8 for the compute_interface_forces_cvx function. 